### PR TITLE
Fix cargo dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,10 @@
 version: 2
 updates:
 - package-ecosystem: cargo
-  directory: "/frontend"
+  directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  commit-message:
-    prefix: "[frontend]"
-- package-ecosystem: cargo
-  directory: "/src-tauri"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  commit-message:
-    prefix: "[src-tauri]"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Because we're in a workspace where the /Cargo.lock has to be updated as well, we cannot seperate these into different dependabot jobs, I believe.
So join them.
