### PR TITLE
Fix: Make parameter names camelCase

### DIFF
--- a/frontend/public/glue.js
+++ b/frontend/public/glue.js
@@ -4,12 +4,12 @@ export async function invoke_configuration_file_path() {
     return await invoke("configuration_file_path");
 }
 
-export async function invoke_load_mastodon(config_file) {
-    return await invoke("load_mastodon", {config_file: config_file});
+export async function invoke_load_mastodon(configFile) {
+    return await invoke("load_mastodon", {configFile: configFile});
 }
 
-export async function invoke_register(instance_url) {
-    return await invoke("register", {instance_url: instance_url});
+export async function invoke_register(instanceUrl) {
+    return await invoke("register", {instanceUrl: instanceUrl});
 }
 
 export async function invoke_finalize_registration(code) {

--- a/frontend/src/tauri.rs
+++ b/frontend/src/tauri.rs
@@ -10,10 +10,10 @@ extern "C" {
     async fn configuration_file_path() -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = invoke_load_mastodon, catch)]
-    async fn load_mastodon(config_file: String) -> Result<JsValue, JsValue>;
+    async fn load_mastodon(configFile: String) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = invoke_register, catch)]
-    async fn register(instance_url: String) -> Result<JsValue, JsValue>;
+    async fn register(instanceUrl: String) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = invoke_finalize_registration, catch)]
     async fn finalize_registration(code: String) -> Result<JsValue, JsValue>;


### PR DESCRIPTION
What a fuckin shitshow is this? Why do these argument names _have to be_ camelcase?