### PR TITLE
Pin mastodon-async to 1.0.1

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "1.2.1", features = [] }
 
 [dependencies]
 futures = "0.3"
-mastodon-async = "1.0.1"
+mastodon-async = "=1.0.1"
 open = "3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
As reported in https://github.com/dscottboggs/mastodon-async/issues/11, the 1.0.2 release is buggy. Pin to 1.0.1 for now.

